### PR TITLE
SVG Logos Added to Assets

### DIFF
--- a/Documentation/ColourOptions.txt
+++ b/Documentation/ColourOptions.txt
@@ -1,0 +1,7 @@
+Main Red: #cc270e 		Highlight Red: #ffe8e5
+
+Main Background: #f2efe6 	Highlight Background: #fcfcfc
+
+Main Dark: #1e1d1d		Highlight Dark: #470808
+
+Gold: #fcce5a			

--- a/src/assets/svgs/black-gold.svg
+++ b/src/assets/svgs/black-gold.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="210mm"
+   height="297mm"
+   viewBox="0 0 210 297"
+   version="1.1"
+   id="svg4682"
+   inkscape:version="0.92.0 r15299"
+   sodipodi:docname="black-gold.svg">
+  <defs
+     id="defs4676" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.29857056"
+     inkscape:cx="358.58353"
+     inkscape:cy="578.05179"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="725"
+     inkscape:window-height="991"
+     inkscape:window-x="718"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata4679">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="opacity:0.81000001;fill:#1e1d1d;fill-opacity:1;stroke:none;stroke-width:0.92965508;stroke-opacity:1"
+       d="M 393.42773 28.851562 A 342.85716 187.14286 0 0 0 50.570312 215.99414 A 342.85716 187.14286 0 0 0 113.16016 323.39453 L 24.646484 997.87891 C 21.557099 1021.4199 38.021486 1042.8579 61.5625 1045.9473 L 157.10156 1058.4844 C 159.63275 1079.7789 177.64329 1096.1895 199.64062 1096.1895 L 579.64062 1096.1895 C 601.37321 1096.1895 619.21631 1080.1721 622.08398 1059.252 L 721.29297 1046.2324 C 744.83398 1043.143 761.29837 1021.7051 758.20898 998.16406 L 670.0293 326.23828 A 342.85716 187.14286 0 0 0 736.28516 215.99414 A 342.85716 187.14286 0 0 0 393.42773 28.851562 z M 310.83008 69.662109 A 28.487394 18.90332 0 0 1 339.31836 88.566406 A 28.487394 18.90332 0 0 1 310.83008 107.46875 A 28.487394 18.90332 0 0 1 282.34375 88.566406 A 28.487394 18.90332 0 0 1 310.83008 69.662109 z M 490.23242 73.931641 A 28.487394 18.90332 0 0 1 518.7207 92.833984 A 28.487394 18.90332 0 0 1 490.23242 111.73828 A 28.487394 18.90332 0 0 1 461.74609 92.833984 A 28.487394 18.90332 0 0 1 490.23242 73.931641 z M 229.34375 160.05859 A 28.487394 18.90332 0 0 1 257.83203 178.96094 A 28.487394 18.90332 0 0 1 229.34375 197.86523 A 28.487394 18.90332 0 0 1 200.85742 178.96094 A 28.487394 18.90332 0 0 1 229.34375 160.05859 z M 586.65625 163.83789 A 28.487394 18.90332 0 0 1 615.14258 182.74219 A 28.487394 18.90332 0 0 1 586.65625 201.64453 A 28.487394 18.90332 0 0 1 558.16797 182.74219 A 28.487394 18.90332 0 0 1 586.65625 163.83789 z M 401.08984 212.99805 A 28.487394 18.90332 0 0 1 429.57617 231.90234 A 28.487394 18.90332 0 0 1 401.08984 250.80469 A 28.487394 18.90332 0 0 1 372.60156 231.90234 A 28.487394 18.90332 0 0 1 401.08984 212.99805 z "
+       transform="scale(0.26458333)"
+       id="path4485-4" />
+    <flowRoot
+       xml:space="preserve"
+       id="flowRoot4649"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:25px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#fcce5a;fill-opacity:1;stroke:none;"
+       transform="matrix(7.013339,0,0,5.3864865,7813.495,-587.23212)"><flowRegion
+         id="flowRegion4651"
+         style="fill:#fcce5a;fill-opacity:1;"><rect
+           id="rect4653"
+           width="968.57141"
+           height="1380"
+           x="-1111.4286"
+           y="133.94826"
+           style="fill:#fcce5a;fill-opacity:1;" /></flowRegion><flowPara
+         id="flowPara4655"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Lucida Bright';-inkscape-font-specification:'Lucida Bright';fill:#fcce5a;fill-opacity:1;">$</flowPara></flowRoot>  </g>
+</svg>

--- a/src/assets/svgs/red-gold.svg
+++ b/src/assets/svgs/red-gold.svg
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg4682"
+   version="1.1"
+   viewBox="0 0 210 297"
+   height="297mm"
+   width="210mm">
+  <defs
+     id="defs4676" />
+  <metadata
+     id="metadata4679">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       id="path4485-4"
+       transform="scale(0.26458333)"
+       d="M 393.42773 28.851562 A 342.85716 187.14286 0 0 0 50.570312 215.99414 A 342.85716 187.14286 0 0 0 113.16016 323.39453 L 24.646484 997.87891 C 21.557099 1021.4199 38.021486 1042.8579 61.5625 1045.9473 L 157.10156 1058.4844 C 159.63275 1079.7789 177.64329 1096.1895 199.64062 1096.1895 L 579.64062 1096.1895 C 601.37321 1096.1895 619.21631 1080.1721 622.08398 1059.252 L 721.29297 1046.2324 C 744.83398 1043.143 761.29837 1021.7051 758.20898 998.16406 L 670.0293 326.23828 A 342.85716 187.14286 0 0 0 736.28516 215.99414 A 342.85716 187.14286 0 0 0 393.42773 28.851562 z M 310.83008 69.662109 A 28.487394 18.90332 0 0 1 339.31836 88.566406 A 28.487394 18.90332 0 0 1 310.83008 107.46875 A 28.487394 18.90332 0 0 1 282.34375 88.566406 A 28.487394 18.90332 0 0 1 310.83008 69.662109 z M 490.23242 73.931641 A 28.487394 18.90332 0 0 1 518.7207 92.833984 A 28.487394 18.90332 0 0 1 490.23242 111.73828 A 28.487394 18.90332 0 0 1 461.74609 92.833984 A 28.487394 18.90332 0 0 1 490.23242 73.931641 z M 229.34375 160.05859 A 28.487394 18.90332 0 0 1 257.83203 178.96094 A 28.487394 18.90332 0 0 1 229.34375 197.86523 A 28.487394 18.90332 0 0 1 200.85742 178.96094 A 28.487394 18.90332 0 0 1 229.34375 160.05859 z M 586.65625 163.83789 A 28.487394 18.90332 0 0 1 615.14258 182.74219 A 28.487394 18.90332 0 0 1 586.65625 201.64453 A 28.487394 18.90332 0 0 1 558.16797 182.74219 A 28.487394 18.90332 0 0 1 586.65625 163.83789 z M 401.08984 212.99805 A 28.487394 18.90332 0 0 1 429.57617 231.90234 A 28.487394 18.90332 0 0 1 401.08984 250.80469 A 28.487394 18.90332 0 0 1 372.60156 231.90234 A 28.487394 18.90332 0 0 1 401.08984 212.99805 z "
+       style="opacity:0.81000001;fill:#cc270e;fill-opacity:1;stroke:none;stroke-width:0.92965508;stroke-opacity:1" />
+    <flowRoot
+       transform="matrix(7.013339,0,0,5.3864865,7813.495,-587.23212)"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:25px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#fcce5a;fill-opacity:1;stroke:none;"
+       id="flowRoot4649"
+       xml:space="preserve"><flowRegion
+         style="fill:#fcce5a;fill-opacity:1;"
+         id="flowRegion4651"><rect
+           style="fill:#fcce5a;fill-opacity:1;"
+           y="133.94826"
+           x="-1111.4286"
+           height="1380"
+           width="968.57141"
+           id="rect4653" /></flowRegion><flowPara
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Lucida Bright';-inkscape-font-specification:'Lucida Bright';fill:#fcce5a;fill-opacity:1;"
+         id="flowPara4655">$</flowPara></flowRoot>  </g>
+</svg>

--- a/src/assets/svgs/white-black.svg
+++ b/src/assets/svgs/white-black.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="210mm"
+   height="297mm"
+   viewBox="0 0 210 297"
+   version="1.1"
+   id="svg4682"
+   inkscape:version="0.92.0 r15299"
+   sodipodi:docname="white-black.svg">
+  <defs
+     id="defs4676" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.29857056"
+     inkscape:cx="358.58353"
+     inkscape:cy="578.05179"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="725"
+     inkscape:window-height="991"
+     inkscape:window-x="718"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata4679">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="opacity:0.81000001;fill:#f2efe6;fill-opacity:1;stroke:none;stroke-width:0.92965508;stroke-opacity:1"
+       d="M 393.42773 28.851562 A 342.85716 187.14286 0 0 0 50.570312 215.99414 A 342.85716 187.14286 0 0 0 113.16016 323.39453 L 24.646484 997.87891 C 21.557099 1021.4199 38.021486 1042.8579 61.5625 1045.9473 L 157.10156 1058.4844 C 159.63275 1079.7789 177.64329 1096.1895 199.64062 1096.1895 L 579.64062 1096.1895 C 601.37321 1096.1895 619.21631 1080.1721 622.08398 1059.252 L 721.29297 1046.2324 C 744.83398 1043.143 761.29837 1021.7051 758.20898 998.16406 L 670.0293 326.23828 A 342.85716 187.14286 0 0 0 736.28516 215.99414 A 342.85716 187.14286 0 0 0 393.42773 28.851562 z M 310.83008 69.662109 A 28.487394 18.90332 0 0 1 339.31836 88.566406 A 28.487394 18.90332 0 0 1 310.83008 107.46875 A 28.487394 18.90332 0 0 1 282.34375 88.566406 A 28.487394 18.90332 0 0 1 310.83008 69.662109 z M 490.23242 73.931641 A 28.487394 18.90332 0 0 1 518.7207 92.833984 A 28.487394 18.90332 0 0 1 490.23242 111.73828 A 28.487394 18.90332 0 0 1 461.74609 92.833984 A 28.487394 18.90332 0 0 1 490.23242 73.931641 z M 229.34375 160.05859 A 28.487394 18.90332 0 0 1 257.83203 178.96094 A 28.487394 18.90332 0 0 1 229.34375 197.86523 A 28.487394 18.90332 0 0 1 200.85742 178.96094 A 28.487394 18.90332 0 0 1 229.34375 160.05859 z M 586.65625 163.83789 A 28.487394 18.90332 0 0 1 615.14258 182.74219 A 28.487394 18.90332 0 0 1 586.65625 201.64453 A 28.487394 18.90332 0 0 1 558.16797 182.74219 A 28.487394 18.90332 0 0 1 586.65625 163.83789 z M 401.08984 212.99805 A 28.487394 18.90332 0 0 1 429.57617 231.90234 A 28.487394 18.90332 0 0 1 401.08984 250.80469 A 28.487394 18.90332 0 0 1 372.60156 231.90234 A 28.487394 18.90332 0 0 1 401.08984 212.99805 z "
+       transform="scale(0.26458333)"
+       id="path4485-4" />
+    <flowRoot
+       xml:space="preserve"
+       id="flowRoot4649"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:25px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#1e1d1d;fill-opacity:1;stroke:none;"
+       transform="matrix(7.013339,0,0,5.3864865,7813.495,-587.23212)"><flowRegion
+         id="flowRegion4651"
+         style="fill:#1e1d1d;fill-opacity:1;"><rect
+           id="rect4653"
+           width="968.57141"
+           height="1380"
+           x="-1111.4286"
+           y="133.94826"
+           style="fill:#1e1d1d;fill-opacity:1;" /></flowRegion><flowPara
+         id="flowPara4655"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Lucida Bright';-inkscape-font-specification:'Lucida Bright';fill:#1e1d1d;fill-opacity:1;">$</flowPara></flowRoot>  </g>
+</svg>

--- a/src/assets/svgs/white-red.svg
+++ b/src/assets/svgs/white-red.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="210mm"
+   height="297mm"
+   viewBox="0 0 210 297"
+   version="1.1"
+   id="svg4682"
+   inkscape:version="0.92.0 r15299"
+   sodipodi:docname="white-red.svg">
+  <defs
+     id="defs4676" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.29857056"
+     inkscape:cx="358.58353"
+     inkscape:cy="578.05179"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="725"
+     inkscape:window-height="991"
+     inkscape:window-x="718"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata4679">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="opacity:0.81000001;fill:#f2efe6;fill-opacity:1;stroke:none;stroke-width:0.92965508;stroke-opacity:1"
+       d="M 393.42773 28.851562 A 342.85716 187.14286 0 0 0 50.570312 215.99414 A 342.85716 187.14286 0 0 0 113.16016 323.39453 L 24.646484 997.87891 C 21.557099 1021.4199 38.021486 1042.8579 61.5625 1045.9473 L 157.10156 1058.4844 C 159.63275 1079.7789 177.64329 1096.1895 199.64062 1096.1895 L 579.64062 1096.1895 C 601.37321 1096.1895 619.21631 1080.1721 622.08398 1059.252 L 721.29297 1046.2324 C 744.83398 1043.143 761.29837 1021.7051 758.20898 998.16406 L 670.0293 326.23828 A 342.85716 187.14286 0 0 0 736.28516 215.99414 A 342.85716 187.14286 0 0 0 393.42773 28.851562 z M 310.83008 69.662109 A 28.487394 18.90332 0 0 1 339.31836 88.566406 A 28.487394 18.90332 0 0 1 310.83008 107.46875 A 28.487394 18.90332 0 0 1 282.34375 88.566406 A 28.487394 18.90332 0 0 1 310.83008 69.662109 z M 490.23242 73.931641 A 28.487394 18.90332 0 0 1 518.7207 92.833984 A 28.487394 18.90332 0 0 1 490.23242 111.73828 A 28.487394 18.90332 0 0 1 461.74609 92.833984 A 28.487394 18.90332 0 0 1 490.23242 73.931641 z M 229.34375 160.05859 A 28.487394 18.90332 0 0 1 257.83203 178.96094 A 28.487394 18.90332 0 0 1 229.34375 197.86523 A 28.487394 18.90332 0 0 1 200.85742 178.96094 A 28.487394 18.90332 0 0 1 229.34375 160.05859 z M 586.65625 163.83789 A 28.487394 18.90332 0 0 1 615.14258 182.74219 A 28.487394 18.90332 0 0 1 586.65625 201.64453 A 28.487394 18.90332 0 0 1 558.16797 182.74219 A 28.487394 18.90332 0 0 1 586.65625 163.83789 z M 401.08984 212.99805 A 28.487394 18.90332 0 0 1 429.57617 231.90234 A 28.487394 18.90332 0 0 1 401.08984 250.80469 A 28.487394 18.90332 0 0 1 372.60156 231.90234 A 28.487394 18.90332 0 0 1 401.08984 212.99805 z "
+       transform="scale(0.26458333)"
+       id="path4485-4" />
+    <flowRoot
+       xml:space="preserve"
+       id="flowRoot4649"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:25px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#cc270e;fill-opacity:1;stroke:none;"
+       transform="matrix(7.013339,0,0,5.3864865,7813.495,-587.23212)"><flowRegion
+         id="flowRegion4651"
+         style="fill:#cc270e;fill-opacity:1;"><rect
+           id="rect4653"
+           width="968.57141"
+           height="1380"
+           x="-1111.4286"
+           y="133.94826"
+           style="fill:#cc270e;fill-opacity:1;" /></flowRegion><flowPara
+         id="flowPara4655"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Lucida Bright';-inkscape-font-specification:'Lucida Bright';fill:#cc270e;fill-opacity:1;">$</flowPara></flowRoot>  </g>
+</svg>


### PR DESCRIPTION
Added 4 logo options, titled "primary-secondary", to use within the app. all in simple svg format

Also added colour palette to docs